### PR TITLE
TR-5: Quick fix for env var problem

### DIFF
--- a/tweets-service/src/server.ls
+++ b/tweets-service/src/server.ls
@@ -139,9 +139,9 @@ function get-mongo-config
 
 function get-mongo-address
   mongo-config = get-mongo-config!
+  return "mongodb://#{process.env.MONGO}/space-tweet-users-dev" if process.env.MONGO
   switch env
     | \test => "mongodb://localhost:27017/space-tweet-tweets-test"
-    | \dev  => "mongodb://#{process.env.MONGO}/space-tweet-tweets-dev"
     | \prod =>
       process.env.MONGODB_USER ? throw new Error "MONGODB_USER not provided"
       process.env.MONGODB_PW ? throw new Error "MONGODB_PW not provided"

--- a/users-service/src/server.ls
+++ b/users-service/src/server.ls
@@ -137,9 +137,9 @@ function get-mongo-config
 
 function get-mongo-address
   mongo-config = get-mongo-config!
+  return "mongodb://#{process.env.MONGO}/space-tweet-users-dev" if process.env.MONGO
   switch env
     | \test => "mongodb://localhost:27017/space-tweet-users-test"
-    | \dev  => "mongodb://#{process.env.MONGO}/space-tweet-users-dev"
     | \prod =>
       process.env.MONGODB_USER ? throw new Error "MONGODB_USER not provided"
       process.env.MONGODB_PW ? throw new Error "MONGODB_PW not provided"


### PR DESCRIPTION
While we determine a more robust solution to setting the `NODE_ENV` to either `dev` or `prod`, this change checks on the value that would be set in `exo-run` which means we are in `dev` mode. If that value does not exist, we shall proceed to check for the default `NODE_ENV` of `test`, or that used in production by docker of `prod`.

Any ideas as to the more robust solution would be appreciated.

@kevgo @hugobho 