### PR TITLE
Health check endpoint for web service

### DIFF
--- a/web-server/app/controllers/home-controller.ls
+++ b/web-server/app/controllers/home-controller.ls
@@ -8,5 +8,8 @@ class HomeController
       res.render 'index', count: data.count, tweets: data.entries
 
 
+  health-check: (req, res) ->
+    res.send-status 200
+
 
 module.exports = HomeController

--- a/web-server/app/routes.ls
+++ b/web-server/app/routes.ls
@@ -4,3 +4,6 @@ module.exports = ({GET, resources}) ->
 
   resources 'tweets' only: <[ create destroy ]>
   resources 'users'
+
+
+  GET '/health-check' to: 'home#healthCheck'


### PR DESCRIPTION
The web service needs an endpoint for AWS Application Load Balancer to hit that returns 200. `/` requires the other services to be online.